### PR TITLE
Add SwiftUI portfolio app

### DIFF
--- a/SwiftPortfolioApp/Colors.swift
+++ b/SwiftPortfolioApp/Colors.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+extension Color {
+    static let softBlue = Color(red: 0x4A/255, green: 0x90/255, blue: 0xE2/255)
+    static let mutedRed = Color(red: 0xFF/255, green: 0x6B/255, blue: 0x6B/255)
+    static let neutralBackground = Color(red: 0xF7/255, green: 0xF7/255, blue: 0xF7/255)
+}
+extension Color {
+    static let accent = Color.softBlue
+}

--- a/SwiftPortfolioApp/ContentView.swift
+++ b/SwiftPortfolioApp/ContentView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            HomeView()
+                .tabItem {
+                    Image(systemName: "house.fill")
+                    Text("Home")
+                }
+
+            SoftwareDevView()
+                .tabItem {
+                    Image(systemName: "laptopcomputer")
+                    Text("Software")
+                }
+
+            PhotographyView()
+                .tabItem {
+                    Image(systemName: "camera.fill")
+                    Text("Photography")
+                }
+
+            VideographyView()
+                .tabItem {
+                    Image(systemName: "video.fill")
+                    Text("Videography")
+                }
+
+            PaperToysView()
+                .tabItem {
+                    Image(systemName: "cube.box.fill")
+                    Text("Paper Toys")
+                }
+        }
+        .accentColor(Color("Accent"))
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/SwiftPortfolioApp/HomeView.swift
+++ b/SwiftPortfolioApp/HomeView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct HomeView: View {
+    @State private var showGreeting = false
+
+    var body: some View {
+        ZStack {
+            Color.neutralBackground.ignoresSafeArea()
+            VStack {
+                if showGreeting {
+                    Text("Welcome to My Portfolio")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .foregroundColor(.accent)
+                        .transition(.opacity)
+                }
+            }
+            .onAppear {
+                withAnimation(.easeIn(duration: 1.0)) {
+                    showGreeting = true
+                }
+            }
+        }
+    }
+}
+
+struct HomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomeView()
+    }
+}

--- a/SwiftPortfolioApp/PaperToysView.swift
+++ b/SwiftPortfolioApp/PaperToysView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import AVKit
+
+struct PaperToy: Identifiable {
+    let id = UUID()
+    let image: String
+    let videoURL: URL
+}
+
+struct PaperToysView: View {
+    let toys: [PaperToy] = [
+        PaperToy(image: "toy1", videoURL: URL(string: "toyVideo1")!),
+        PaperToy(image: "toy2", videoURL: URL(string: "toyVideo2")!),
+        PaperToy(image: "toy3", videoURL: URL(string: "toyVideo3")!)
+    ]
+
+    @State private var selectedVideo: URL? = nil
+
+    var body: some View {
+        ZStack {
+            Color.neutralBackground.ignoresSafeArea()
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 16) {
+                    ForEach(toys) { toy in
+                        VStack(spacing: 8) {
+                            Image(toy.image)
+                                .resizable()
+                                .frame(width: 200, height: 200)
+                                .cornerRadius(10)
+                                .shadow(radius: 2)
+                                .onTapGesture {
+                                    selectedVideo = toy.videoURL
+                                }
+                            Text("Watch Assembly")
+                                .foregroundColor(.accent)
+                        }
+                    }
+                }
+                .padding()
+            }
+            if let url = selectedVideo {
+                VideoPlayer(player: AVPlayer(url: url))
+                    .edgesIgnoringSafeArea(.all)
+                    .onTapGesture {
+                        selectedVideo = nil
+                    }
+            }
+        }
+    }
+}
+
+struct PaperToysView_Previews: PreviewProvider {
+    static var previews: some View {
+        PaperToysView()
+    }
+}

--- a/SwiftPortfolioApp/PhotographyView.swift
+++ b/SwiftPortfolioApp/PhotographyView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct ZoomableImage: View {
+    let imageName: String
+    @State private var scale: CGFloat = 1.0
+
+    var body: some View {
+        Image(imageName)
+            .resizable()
+            .scaledToFit()
+            .gesture(MagnificationGesture()
+                        .onChanged { value in
+                            scale = value
+                        }
+            )
+            .scaleEffect(scale)
+            .animation(.easeInOut, value: scale)
+    }
+}
+
+struct PhotographyView: View {
+    let images = ["photo1", "photo2", "photo3", "photo4", "photo5", "photo6"]
+
+    @State private var selectedImage: String? = nil
+
+    let columns = [GridItem(.adaptive(minimum: 120), spacing: 16)]
+
+    var body: some View {
+        ZStack {
+            Color.neutralBackground.ignoresSafeArea()
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(images, id: \.self) { img in
+                        Image(img)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(height: 120)
+                            .clipped()
+                            .cornerRadius(10)
+                            .shadow(radius: 2)
+                            .onTapGesture {
+                                selectedImage = img
+                            }
+                    }
+                }
+                .padding()
+            }
+            if let img = selectedImage {
+                Color.black.opacity(0.8).ignoresSafeArea()
+                ZoomableImage(imageName: img)
+                    .onTapGesture {
+                        selectedImage = nil
+                    }
+            }
+        }
+    }
+}
+
+struct PhotographyView_Previews: PreviewProvider {
+    static var previews: some View {
+        PhotographyView()
+    }
+}

--- a/SwiftPortfolioApp/PortfolioAppApp.swift
+++ b/SwiftPortfolioApp/PortfolioAppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct PortfolioAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/SwiftPortfolioApp/SoftwareDevView.swift
+++ b/SwiftPortfolioApp/SoftwareDevView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct Project: Identifiable {
+    let id = UUID()
+    let title: String
+    let description: String
+}
+
+struct SoftwareDevView: View {
+    let projects: [Project] = [
+        Project(title: "App 1", description: "A cool iOS application."),
+        Project(title: "App 2", description: "Another awesome project."),
+        Project(title: "App 3", description: "SwiftUI demo with animations.")
+    ]
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                ForEach(projects) { project in
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(project.title)
+                            .font(.headline)
+                            .foregroundColor(.primary)
+                        Text(project.description)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                        Button(action: {}) {
+                            Text("View Details")
+                                .padding()
+                                .frame(maxWidth: .infinity)
+                                .background(Color.accent)
+                                .foregroundColor(.white)
+                                .cornerRadius(10)
+                        }
+                    }
+                    .padding()
+                    .background(Color.white)
+                    .cornerRadius(12)
+                    .shadow(color: Color.black.opacity(0.1), radius: 5, x: 0, y: 2)
+                    .padding(.horizontal)
+                }
+            }
+            .padding(.top)
+        }
+        .background(Color.neutralBackground)
+    }
+}
+
+struct SoftwareDevView_Previews: PreviewProvider {
+    static var previews: some View {
+        SoftwareDevView()
+    }
+}

--- a/SwiftPortfolioApp/VideographyView.swift
+++ b/SwiftPortfolioApp/VideographyView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+import AVKit
+
+struct VideoItem: Identifiable {
+    let id = UUID()
+    let url: URL
+    let thumbnail: String
+}
+
+struct VideographyView: View {
+    let videos: [VideoItem] = [
+        VideoItem(url: URL(string: "video1")!, thumbnail: "videoThumb1"),
+        VideoItem(url: URL(string: "video2")!, thumbnail: "videoThumb2"),
+        VideoItem(url: URL(string: "video3")!, thumbnail: "videoThumb3")
+    ]
+
+    @State private var selectedVideo: URL? = nil
+
+    var body: some View {
+        ZStack {
+            Color.neutralBackground.ignoresSafeArea()
+            ScrollView {
+                VStack(spacing: 16) {
+                    ForEach(videos) { video in
+                        Image(video.thumbnail)
+                            .resizable()
+                            .scaledToFit()
+                            .cornerRadius(10)
+                            .shadow(radius: 2)
+                            .onTapGesture {
+                                selectedVideo = video.url
+                            }
+                    }
+                }
+                .padding()
+            }
+            if let url = selectedVideo {
+                VideoPlayer(player: AVPlayer(url: url))
+                    .edgesIgnoringSafeArea(.all)
+                    .onTapGesture {
+                        selectedVideo = nil
+                    }
+            }
+        }
+    }
+}
+
+struct VideographyView_Previews: PreviewProvider {
+    static var previews: some View {
+        VideographyView()
+    }
+}


### PR DESCRIPTION
## Summary
- create SwiftPortfolioApp with minimal SwiftUI layout
- add Home view with animated greeting
- add Software Development card list
- create Photography image grid with pinch zoom
- build Videography and Paper Toys sections with video playback

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686ec3e11710832186d52d6d6eaa6a3d